### PR TITLE
Create 23.08 branch

### DIFF
--- a/org.freedesktop.Sdk.Extension.node14.yaml
+++ b/org.freedesktop.Sdk.Extension.node14.yaml
@@ -1,7 +1,7 @@
 app-id: org.freedesktop.Sdk.Extension.node14
-branch: '22.08'
+branch: '23.08'
 runtime: org.freedesktop.Sdk
-runtime-version: '22.08'
+runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 build-extension: true
 separate-locales: false


### PR DESCRIPTION
An example of a Flatpak that still uses this extension is [com.wickeditor.WickEditor](https://github.com/flathub/com.wickeditor.WickEditor). I _am_ currently trying to get that Flatpak to use the [Node.js 18 extension](https://github.com/flathub/org.freedesktop.Sdk.Extension.node18) instead while concurrently updating its Freedesktop runtime (see flathub/com.wickeditor.WickEditor#2), but I'm also facing issues which I have described here: flathub/org.freedesktop.Sdk.Extension.node18#40

Until those issues there get resolved, it seems like this extension may still need a 23.08 branch, at least for [com.wickeditor.WickEditor](https://github.com/flathub/com.wickeditor.WickEditor) and other applications still using Node.js 14 for their build processes (despite it being EOL). I created this PR to facilitate that.